### PR TITLE
Refactor project configuration

### DIFF
--- a/.github/workflows/build-timestamped-master.yml
+++ b/.github/workflows/build-timestamped-master.yml
@@ -7,42 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'ballerina-platform'
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 21
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'adopt'
-          java-version: 21.0.3
-      - name: Change to Timestamped Version
-        run: |
-          startTime=$(TZ="Asia/Kolkata" date +'%Y%m%d-%H%M00')
-          latestCommit=$(git log -n 1 --pretty=format:"%h")
-          VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)
-          updatedVersion=$VERSION-$startTime-$latestCommit
-          echo $updatedVersion
-          sed -i "s/version=\(.*\)/version=$updatedVersion/g" gradle.properties
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - uses: graalvm/setup-graalvm@v1
-        with:
-          java-version: '21.0.1'
-          distribution: 'graalvm-community'
-          components: 'native-image'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          set-java-home: 'false'
-      - name: Build with Gradle
-        env:
-          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-          publishUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-          publishPAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-        run: |
-          ./gradlew publish -PnativeTest --scan --no-daemon
-      - name: Generate CodeCov Report
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+  call_workflow:
+    name: Run Build Workflow
+    if: ${{ github.repository_owner == 'ballerina-platform' }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/build-timestamp-master-template.yml@main
+    secrets: inherit

--- a/ballerina-tests/artifacts-tests/Dependencies.toml
+++ b/ballerina-tests/artifacts-tests/Dependencies.toml
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.0"
+version = "2.14.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "auth"},

--- a/ballerina-tests/build.gradle
+++ b/ballerina-tests/build.gradle
@@ -29,15 +29,13 @@ def packageOrg = "ballerina"
 def moduleName = "tests"
 def tomlVersion = stripBallerinaExtensionVersion("${project.version}")
 def ballerinaTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/BallerinaTest.toml")
-def ballerinaDist = "${project.rootDir}/target/ballerina-runtime"
-def distributionBinPath =  "${ballerinaDist}/bin"
-def testCoverageParam = "--code-coverage --coverage-format=xml --includes=io.ballerina.wso2.controlplane.*:ballerina." +
+def testCoverageParams = "--code-coverage --coverage-format=xml --includes=io.ballerina.wso2.controlplane.*:ballerina." +
         "wso2.controlplane*"
 def testPackages = ["artifacts-tests"]
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
-        def splitVersion = extVersion.split('-');
+        def splitVersion = extVersion.split('-')
         if (splitVersion.length > 3) {
             def strippedValues = splitVersion[0..-4]
             return strippedValues.join('-')
@@ -47,17 +45,6 @@ def stripBallerinaExtensionVersion(String extVersion) {
     } else {
         return extVersion.replace("${project.ext.snapshotVersion}", "")
     }
-}
-
-configurations {
-    jbalTools
-}
-
-dependencies {
-    jbalTools ("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
-        transitive = false
-    }
-    implementation group: 'org.ballerinalang', name: 'toml-parser', version: "${ballerinaTomlParserVersion}"
 }
 
 clean {
@@ -87,7 +74,7 @@ task updateTomlVersions {
 
 task commitTomlFiles {
     doLast {
-        def files = " ";
+        def files = " "
         testPackages.each{ testPackage ->
             files += "${testPackage}/Ballerina.toml ${testPackage}/Dependencies.toml "
         }
@@ -112,6 +99,9 @@ def testParams = ""
 def graalvmFlag = ""
 def parallelTestFlag = ""
 def skipTests = false
+def ballerinaDockerTag = ""
+def projectDirectory = new File("$project.projectDir")
+def parentDirectory = new File("$projectDirectory.parent")
 
 task initializeVariables {
     if (project.hasProperty("groups")) {
@@ -140,15 +130,55 @@ task initializeVariables {
             testPackages.remove(testPackage)
         }
     }
+    ballerinaDockerTag = getDockerImageTag(project)
+    println("[Info] project builds on docker")
+    println("[Info] using the Ballerina docker image tag: $ballerinaDockerTag")
 
     gradle.taskGraph.whenReady { graph ->
         if (graph.hasTask(":${packageName}-ballerina-tests:test")) {
             if (!project.hasProperty('balGraalVMTest')) {
-                testParams = "${testCoverageParam}"
+                testParams = "${testCoverageParams}"
             }
         } else {
             skipTests = true
         }
+    }
+}
+
+static String getDockerImageTag(Project project) {
+    def ballerinaDockerTag = project.findProperty('ballerinaLangVersion')
+    if (project.hasProperty('buildUsingDocker')) {
+        ballerinaDockerTag = project.findProperty('buildUsingDocker')
+        if (ballerinaDockerTag == '') {
+            return 'nightly'
+        }
+    }
+    if (isTimeStampVersion(ballerinaDockerTag as String)) {
+        return 'nightly'
+    }
+    return ballerinaDockerTag
+}
+
+static boolean isTimeStampVersion(String version) {
+    return version.trim().split("-").length > 1
+}
+
+static void createDockerEnvFile(String dockerEnvFilePath) {
+    def dockerEnvFileWriter = new PrintWriter("$dockerEnvFilePath", "UTF-8")
+    def excludedVariables = ["PATH", "JAVA_HOME", "HOME"]
+    def envVariables = System.getenv()
+    envVariables.each { key, value ->
+        if (!excludedVariables.contains(key) && !key.startsWith("=")) {
+            dockerEnvFileWriter.println("$key=$value")
+        }
+    }
+    dockerEnvFileWriter.close()
+}
+
+static void deleteFile(String filePath) {
+    def file = new File(filePath)
+    if (file.exists() && !file.delete()) {
+        println("Failed to delete $filePath.")
     }
 }
 
@@ -170,26 +200,25 @@ task ballerinaTest {
                 exec {
                     workingDir "${project.projectDir}/${testPackage}"
                     environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
+                    createDockerEnvFile("$project.projectDir/$testPackage/docker.env")
                     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                        commandLine 'cmd', '/c', "${balJavaDebugParam} ${distributionBinPath}/bal.bat test ${graalvmFlag}" +
-                                " ${parallelTestFlag} ${testParams} ${groupParams} ${disableGroups} ${windowsDisableGroups}" +
-                                "  ${debugParams} && exit %%ERRORLEVEL%%"
+                        disableGroups = disableGroups + windowsDisableGroups
+                    }
+                    def balTestWithDocker = """
+                            docker run --env-file $project.projectDir/$testPackage/docker.env --rm --net=host -u root \
+                                -v $parentDirectory:/home/ballerina/$parentDirectory.name \
+                                -v $projectDirectory/$testPackage:/home/ballerina/$parentDirectory.name/$projectDirectory.name/$testPackage \
+                                ballerina/ballerina:$ballerinaDockerTag \
+                                /bin/sh -c "cd $parentDirectory.name/$projectDirectory.name/$testPackage && \
+                                $balJavaDebugParam bal test ${graalvmFlag} ${parallelTestFlag} ${testParams} ${groupParams} ${disableGroups} ${debugParams}"
+                        """
+                    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                        commandLine 'cmd', '/c', "$balTestWithDocker && exit %%ERRORLEVEL%%"
                     } else {
-                        commandLine 'sh', '-c', "${balJavaDebugParam} ${distributionBinPath}/bal test ${graalvmFlag} ${parallelTestFlag} ${testParams}" +
-                                " ${groupParams} ${disableGroups} ${debugParams}"
+                        commandLine 'sh', '-c', "$balTestWithDocker"
                     }
                 }
-                if (project.hasProperty('balGraalVMTest')) {
-                    exec {
-                        workingDir "${project.projectDir}/${testPackage}"
-                        environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
-                        if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                            commandLine 'cmd', '/c', "${distributionBinPath}/bal.bat clean"
-                        } else {
-                            commandLine 'sh', '-c', "${distributionBinPath}/bal clean"
-                        }
-                    }
-                }
+                deleteFile("$project.projectDir/$testPackage/docker.env")
             }
         }
     }

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerinax"
 name = "wso2.controlplane"
 version = "1.1.0"
-distribution = "2201.11.0-20241218-101200-109f6cc7"
+distribution = "2201.12.2"
 repository = "https://github.com/ballerina-platform/module-ballerinax-wso2.controlplane"
 license = ["Apache-2.0"]
 
@@ -10,4 +10,4 @@ license = ["Apache-2.0"]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
-path = "../native/build/libs/wso2.controlplane-native-1.1.0.jar"
+path = "../native/build/libs/wso2.controlplane-native-1.1.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -73,7 +73,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -26,13 +26,13 @@ def packageName = "wso2.controlplane"
 def packageOrg = "ballerinax"
 
 def tomlVersion = stripBallerinaExtensionVersion("${project.version}")
+def ballerinaLangVersion = project.ext.ballerinaLangVersion
 def ballerinaTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/Ballerina.toml")
 def ballerinaTomlFile = new File("$project.projectDir/Ballerina.toml")
-def ballerinaCentralAccessToken = System.getenv('BALLERINA_CENTRAL_ACCESS_TOKEN')
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
-        def splitVersion = extVersion.split('-');
+        def splitVersion = extVersion.split('-')
         if (splitVersion.length > 3) {
             def strippedValues = splitVersion[0..-4]
             return strippedValues.join('-')
@@ -48,20 +48,14 @@ ballerina {
     packageOrganization = packageOrg
     module = packageName
     langVersion = ballerinaLangVersion
-    testCoverageParam = "--code-coverage --coverage-format=xml"
-    packageOrganization = packageOrg
-    platform = "java21"
     isConnector = true
-}
-
-configurations {
-    externalJars
 }
 
 task updateTomlFiles {
     doLast {
         def newConfig = ballerinaTomlFilePlaceHolder.text.replace("@project.version@", project.version)
         newConfig = newConfig.replace("@toml.version@", tomlVersion)
+        newConfig = newConfig.replace("@ballerina.version@", ballerinaLangVersion)
         ballerinaTomlFile.text = newConfig
     }
 }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerinax"
 name = "wso2.controlplane"
 version = "@toml.version@"
-distribution = "2201.11.0-20241218-101200-109f6cc7"
+distribution = "@ballerina.version@"
 repository = "https://github.com/ballerina-platform/module-ballerinax-wso2.controlplane"
 license = ["Apache-2.0"]
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,6 @@ plugins {
 }
 
 ext.ballerinaLangVersion = project.ballerinaLangVersion
-ext.stdlibHttpVersion = project.stdlibHttpVersion
-ext.stdlibLogVersion = project.stdlibLogVersion
 ext.ballerinaTomlParserVersion = project.ballerinaTomlParserVersion
 
 ext.puppycrawlCheckstyleVersion = project.puppycrawlCheckstyleVersion
@@ -65,42 +63,6 @@ allprojects {
 }
 
 def moduleVersion = project.version.replace("-SNAPSHOT", "")
-
-subprojects {
-    configurations {
-        ballerinaStdLibs
-        jbalTools
-    }
-    dependencies {
-        /* JBallerina Tools */
-        jbalTools ("org.ballerinalang:jballerina-tools:${ballerinaLangVersion}") {
-            transitive = false
-        }
-
-        /* Standard libraries */
-        ballerinaStdLibs "io.ballerina.stdlib:http-ballerina:${stdlibHttpVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:log-ballerina:${stdlibLogVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:io-ballerina:${stdlibIoVersion}"
-
-        // Transitive dependencies for HTTP module
-        ballerinaStdLibs "io.ballerina.stdlib:file-ballerina:${stdlibFileVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:crypto-ballerina:${stdlibCryptoVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:auth-ballerina:${stdlibAuthVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:mime-ballerina:${stdlibMimeVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:jwt-ballerina:${stdlibJwtVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:oauth2-ballerina:${stdlibOAuth2Version}"
-        ballerinaStdLibs "io.ballerina.stdlib:constraint-ballerina:${stdlibConstraintVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:url-ballerina:${stdlibUrlVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:os-ballerina:${stdlibOsVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:task-ballerina:${stdlibTaskVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:time-ballerina:${stdlibTimeVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:cache-ballerina:${stdlibCacheVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:observe-ballerina:${observeVersion}"
-        ballerinaStdLibs "io.ballerina:observe-ballerina:${observeInternalVersion}"
-        ballerinaStdLibs "io.ballerina.stdlib:uuid-ballerina:${stdlibUuidVersion}"
-        ballerinaStdLibs "io.ballerina.lib:data.jsondata-ballerina:${stdlibDataJsondataVersion}"
-    }
-}
 
 release {
     failOnPublishNeeded = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=1.1.0
+version=1.1.0-SNAPSHOT
 
 puppycrawlCheckstyleVersion=10.12.0
 jacocoVersion=0.8.10
@@ -12,25 +12,5 @@ shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
 releasePluginVersion=2.8.0
 
-stdlibIoVersion=1.8.0
-stdlibHttpVersion=2.14.0
-stdlibDataJsondataVersion=1.1.0
-stdlibLogVersion=2.12.0
-stdlibFileVersion=1.12.0
-stdlibCryptoVersion=2.9.0
-stdlibAuthVersion=2.14.0
-stdlibMimeVersion=2.12.0
-stdlibJwtVersion=2.15.0
-stdlibOAuth2Version=2.14.0
-stdlibConstraintVersion=1.7.0
-stdlibOsVersion=1.10.0
-stdlibTaskVersion=2.7.0
-stdlibTimeVersion=2.7.0
-stdlibCacheVersion=3.10.0
-stdlibUrlVersion=2.6.0
-observeVersion=1.5.0
-observeInternalVersion=1.5.0
-stdlibUuidVersion=1.10.0
-
-ballerinaGradlePluginVersion=3.0.0
+ballerinaGradlePluginVersion=2.3.0
 spotbugsVersion=6.0.18


### PR DESCRIPTION
## Purpose

Even though the project is configured as a connector (in the Ballerina Gradle plugin) where the package is build on top of the released version of a Ballerina distribution, the sub projects inconsistently using the temporary distribution approach. This PR is created to fix that. Additionally the Ballerina Gradle plugin version is downgraded to `2.3.0` since the `3.0.0` is not fully compatible with the existing connector workflow templates
